### PR TITLE
Feat/app privileges

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM php:7.0.6-apache
 MAINTAINER Minca Daniel Andrei <mandrei17@gmail.com>
+USER $USER
 RUN apt-get update -qq \
   && apt-get install -yqq libapache2-mod-auth-pgsql libpng12-dev libjpeg-dev libpq-dev \
   && rm -rf /var/lib/apt/lists/* \

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ restart:
 	docker-compose restart
 
 clean: clean-containers clean-images
-	sudo rm -rf app
+	rm -rf app
 
 clean-containers:
 	docker rm -v $$(docker ps -aq -f status=exited)
@@ -36,13 +36,10 @@ build-drupal:
 	rm -rf app/$(DRUPAL_SRCNAME).tar.gz
 	cp $(DRUPAL_SITES)/default.settings.php $(DRUPAL_SITES)/settings.php
 	cp $(DRUPAL_SITES)/default.services.yml $(DRUPAL_SITES)/services.yml
-	chmod 644 $(DRUPAL_SITES)/settings.php $(DRUPAL_SITES)/services.yml
-	chmod 755 $(DRUPAL_SITES)
+	chmod a+w $(DRUPAL_SITES)/settings.php $(DRUPAL_SITES)/services.yml
+	chmod a+w $(DRUPAL_SITES)
 	mkdir $(DRUPAL_SITES)/files
-	chmod 755 $(DRUPAL_SITES)/files
-	sudo chown -R www-data:www-data app/sites
-	sudo chown www-data:www-data app/themes
-	sudo chown www-data:www-data app/modules
+	chmod a+w $(DRUPAL_SITES)/files
 
 test: build-drupal build up restart down clean
 


### PR DESCRIPTION
Give the developer privileges to edit any file within the `app/` folder.

#### Error description
This :red_circle: Error was mostly observed when editing code from other folders except `sites/default` or `/themes` or `/modules`, Sublime Text would throw a :warning: popup that user doesn't have privileges to edit the file in cause.