### PR TITLE
Solve Database Hostname issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/dminca/dockerized-drupal.svg?branch=master)](https://travis-ci.org/dminca/dockerized-drupal)
+[![Build Status](https://travis-ci.org/dminca/dockerized-drupal.svg?branch=master)](https://travis-ci.org/dminca/dockerized-drupal) [![](https://imagelayers.io/badge/completit/dockerized-drupal:latest.svg)](https://imagelayers.io/?images=completit/dockerized-drupal:latest 'Get your own badge on imagelayers.io')
 # Drupal dev env based on Docker
 > Run Drupal **8.1.1** from Docker containers
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.org/dminca/dockerized-drupal.svg?branch=master)](https://travis-ci.org/dminca/dockerized-drupal) [![](https://imagelayers.io/badge/completit/dockerized-drupal:latest.svg)](https://imagelayers.io/?images=completit/dockerized-drupal:latest 'Get your own badge on imagelayers.io')
 # Drupal dev env based on Docker
-> Run Drupal **8.1.1** from Docker containers
+> Run Drupal **8.1.2** from Docker containers
 
 ## Running the project
 
@@ -21,18 +21,18 @@ make up
 :boom: And that's it, you got yourself a fully-functional Drupal website on 
 localhost without wasting time to install _Apache + PHP + Drupal_ on your machine.
 
-## During Drupal install
-At the **Set up database** step you need to add the **PostgreSQL container IPAddress**.
-```bash
-docker inspect -f '{{.NetworkSettings.IPAddress}}' dockerizeddrupal_psql_1
-```
-where `dockerizeddrupal_psql_1` is the **container name**
+## Credentials
+The following credentials are used along the installation:
+* **DB_USERNAME:** `drupal`
+* **DB_PASSWORD:** `drupal`
+* **DB_DATABASE:** `drupal`
+* **DB_HOSTNAME:** `dockerizeddrupal_mysql_1` or `dockerizeddrupal_psql_1`
 
-or MySQL container IP Address:
-```bash
-docker inspect -f '{{.NetworkSettings.IPAddress}}' dockerizeddrupal_mysql_1
-```
-in case you're using MySQL.
+Choose the proper `DB_HOSTNAME` depending on which Database you use: MySQL or PostgreSQL.
+
+#### Note for DB_HOSTNAME
+In case there are problems with the host of the db, do `docker ps` and copy the NAME of
+the DB Docker container
 
 ## Other commands
 ```bash


### PR DESCRIPTION
##### Description of change
<!-- provide a description of the change below this comment -->

during Drupal installation, the DB Hostname was mapped to its specific
IP forcing the User to get the IP of the DB Container

Docker has the ability to map the container name to your local hosts

The DB container name is printed right after all containers have
started. Alternatively, it can be found via `docker ps` in the NAME
column.

As a result, the db container name will be used when Drupal installer
asks for db hostname

Resolves: #14
Resolves: #20
Signed-off-by: Minca Daniel Andrei <dminca@marketstheworld.com>